### PR TITLE
docs: update README with working example

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,27 @@ There are two hooks available:
 Kyverno CLI must be installed
 
 [Please use these instructions](https://kyverno.io/docs/kyverno-cli/)
+
+## Example Usage
+
+create .pre-commit-config.yaml at the root of repo
+
+```yaml
+repos:
+  - repo: https://github.com/kyverno/pre-commit-hook
+    rev: v1.0.0
+    hooks:
+      - id: kyverno-test
+        args: ["kyverno-policies"]
+      - id: kyverno-validate
+        args: ["kyverno-policies"]
+```
+
+*Note: the args for each hook should be the directory where your kyverno policies are stored*
+
+then run:
+
+`pre-commit install`
+`pre-commit run --all-files`
+
+Further configuration of pre-commit (to only run on push, for example) see the [Pre-commit Documentation](https://pre-commit.com)


### PR DESCRIPTION
@realshuting This gives a working example for a pre-commit hook that runs both test and validate on the policies. 

The only thing we need to do, after merging this, is to create a v1.0.0 release on this repo to reference.

Signed-off-by: Hans Knecht <Hans.Knecht@missionlane.com>